### PR TITLE
Use broadcast-receivers in place of binder

### DIFF
--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/CustomIcons.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/CustomIcons.kt
@@ -1,0 +1,7 @@
+package xyz.thespud.skimap.activities
+
+interface CustomIcons {
+
+	fun getOtherIcon(name: String): Int
+
+}

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
@@ -27,9 +27,10 @@ import xyz.thespud.skimap.mapItem.MapMarker
 import xyz.thespud.skimap.mapItem.SkiRuns
 import kotlin.math.roundToInt
 
-class InfoMapActivity(val activity: AppCompatActivity, cameraPosition: CameraPosition, cameraBounds: LatLngBounds?,
-                               skiRuns: SkiRuns, otherIconCallback: CustomIcons, showDebug: Boolean = false): MapHandler(activity,
-	cameraPosition, cameraBounds, skiRuns, otherIconCallback, true, showDebug), GoogleMap.InfoWindowAdapter {
+class InfoMapActivity(val activity: AppCompatActivity, view: View, cameraPosition: CameraPosition,
+                      cameraBounds: LatLngBounds?, skiRuns: SkiRuns, otherIconCallback: CustomIcons,
+                      showDebug: Boolean = false): MapHandler(activity, view, cameraPosition,
+	cameraBounds, skiRuns, otherIconCallback, true, showDebug), GoogleMap.InfoWindowAdapter {
 
 	var circles: MutableList<Circle> = mutableListOf()
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
@@ -28,8 +28,8 @@ import xyz.thespud.skimap.mapItem.SkiRuns
 import kotlin.math.roundToInt
 
 class InfoMapActivity(val activity: AppCompatActivity, cameraPosition: CameraPosition, cameraBounds: LatLngBounds?,
-                               skiRuns: SkiRuns, showDebug: Boolean = false): MapHandler(activity,
-	cameraPosition, cameraBounds, skiRuns, true, showDebug), GoogleMap.InfoWindowAdapter {
+                               skiRuns: SkiRuns, otherIconCallback: CustomIcons, showDebug: Boolean = false): MapHandler(activity,
+	cameraPosition, cameraBounds, skiRuns, otherIconCallback, true, showDebug), GoogleMap.InfoWindowAdapter {
 
 	var circles: MutableList<Circle> = mutableListOf()
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -4,15 +4,14 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.AlertDialog
-import android.content.ComponentName
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.Build
-import android.os.IBinder
 import android.os.Process
 import android.util.Log
 import android.widget.Toast
@@ -39,16 +38,12 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 	private set
 	var isTrackingLocation = false
 
+	private val startTrackingReceiver = object : BroadcastReceiver() {
+		override fun onReceive(context: Context?, intent: Intent?) { setIsTracking(true) }
+	}
 
-	private val serviceConnection = object : ServiceConnection {
-
-		override fun onServiceConnected(name: ComponentName?, service: IBinder) {
-			setIsTracking(true)
-		}
-
-		override fun onServiceDisconnected(name: ComponentName?) {
-			setIsTracking(false)
-		}
+	private val stopTrackingReceiver = object : BroadcastReceiver() {
+		override fun onReceive(context: Context?, intent: Intent?) { setIsTracking(false) }
 	}
 
 	override val additionalCallback: OnMapReadyCallback = OnMapReadyCallback {
@@ -80,7 +75,6 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 			alertDialogBuilder.create().show()
 		}
 
-		// googleMap.setPadding(leftPadding, topPadding, rightPadding, bottomPadding)
 		isMapSetup = true
 	}
 
@@ -154,15 +148,23 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 				}
 			}
 
-			activity.bindService(serviceIntent, serviceConnection, Context.BIND_NOT_FOREGROUND)
 			activity.startService(serviceIntent)
 		} else {
 			Log.w("launchLocationService", "GPS not enabled")
 		}
 	}
 
+	init {
+		ContextCompat.registerReceiver(activity, startTrackingReceiver,
+			IntentFilter(SkierLocationService.START_TRACKING_BROADCAST),
+			ContextCompat.RECEIVER_EXPORTED)
+
+		ContextCompat.registerReceiver(activity, stopTrackingReceiver,
+			IntentFilter(SkierLocationService.STOP_TRACKING_BROADCAST),
+			ContextCompat.RECEIVER_EXPORTED)
+	}
+
 	companion object {
 		const val permissionValue = 29500
 	}
-
 }

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -75,6 +75,9 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 			alertDialogBuilder.create().show()
 		}
 
+		// Apply map insets to fix edge to edge behavior
+		applyMapInsets(activity.window.decorView)
+
 		isMapSetup = true
 	}
 
@@ -152,6 +155,12 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 		} else {
 			Log.w("launchLocationService", "GPS not enabled")
 		}
+	}
+
+	override fun destroy() {
+		super.destroy()
+		activity.unregisterReceiver(startTrackingReceiver)
+		activity.unregisterReceiver(stopTrackingReceiver)
 	}
 
 	init {

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -14,6 +14,7 @@ import android.location.LocationManager
 import android.os.Build
 import android.os.Process
 import android.util.Log
+import android.view.View
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -28,9 +29,10 @@ import xyz.thespud.skimap.mapItem.SkiRuns
 import xyz.thespud.skimap.services.SkierLocationService
 import xyz.thespud.skimap.services.SkiingNotification.NOTIFICATION_PERMISSION
 
-class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosition, cameraBounds: LatLngBounds?,
-                      skiRuns: SkiRuns, otherIconCallback: CustomIcons, showDebug: Boolean = false): MapHandler(activity,
-	cameraPosition, cameraBounds, skiRuns, otherIconCallback, false, showDebug), GoogleMap.OnMyLocationClickListener {
+class LiveMapActivity(val activity: FragmentActivity, view: View, cameraPosition: CameraPosition,
+                      cameraBounds: LatLngBounds?, skiRuns: SkiRuns, otherIconCallback: CustomIcons,
+                      showDebug: Boolean = false): MapHandler(activity, view, cameraPosition, cameraBounds,
+	skiRuns, otherIconCallback, false, showDebug), GoogleMap.OnMyLocationClickListener {
 
 	var isMapSetup = false
 
@@ -74,9 +76,6 @@ class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosi
 			// Show the info popup about location.
 			alertDialogBuilder.create().show()
 		}
-
-		// Apply map insets to fix edge to edge behavior
-		applyMapInsets(activity.window.decorView)
 
 		isMapSetup = true
 	}

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -30,8 +30,8 @@ import xyz.thespud.skimap.services.SkierLocationService
 import xyz.thespud.skimap.services.SkiingNotification.NOTIFICATION_PERMISSION
 
 class LiveMapActivity(val activity: FragmentActivity, cameraPosition: CameraPosition, cameraBounds: LatLngBounds?,
-                               skiRuns: SkiRuns, showDebug: Boolean = false): MapHandler(activity,
-	cameraPosition, cameraBounds, skiRuns, false, showDebug), GoogleMap.OnMyLocationClickListener {
+                      skiRuns: SkiRuns, otherIconCallback: CustomIcons, showDebug: Boolean = false): MapHandler(activity,
+	cameraPosition, cameraBounds, skiRuns, otherIconCallback, false, showDebug), GoogleMap.OnMyLocationClickListener {
 
 	var isMapSetup = false
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -1,14 +1,11 @@
 package xyz.thespud.skimap.activities
 
-import android.app.Activity
-import android.content.Context
 import android.util.Log
 import android.view.View
 import androidx.annotation.AnyThread
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.RawRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.FragmentActivity
@@ -42,7 +39,7 @@ import xyz.thespud.skimap.mapItem.SkiRuns
 
 abstract class MapHandler(private val activity: FragmentActivity, private val cameraPosition: CameraPosition,
                           private val cameraBounds: LatLngBounds?, private val skiRuns: SkiRuns,
-                          private val drawOpaqueRuns: Boolean, private val showDebug: Boolean): OnMapReadyCallback {
+                          private val otherIconCallback: CustomIcons, private val drawOpaqueRuns: Boolean, private val showDebug: Boolean): OnMapReadyCallback {
 
 	internal var googleMap: GoogleMap? = null
 
@@ -304,15 +301,18 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 			Log.d(tag, "Adding other bounds")
 			val sanitizedOtherBounds = mutableListOf<PolygonMapItem>()
 
-			val iconRes = R.drawable.ic_missing // getOtherIcon("") // FIXME
-
-			val otherPolygons = loadPolygons(skiRuns.other, R.color.other_polygon_fill, iconRes)
+			val otherPolygons = loadPolygons(skiRuns.other, R.color.other_polygon_fill,
+				R.drawable.ic_missing)
 			for (polygon in otherPolygons) {
 				if (polygon.name == "Ski Area Bounds") {
 					Locations.skiAreaBounds = polygon
 					continue
 				}
-				sanitizedOtherBounds.add(polygon)
+
+				// Update the icon based on the name of the other location
+				val icon = otherIconCallback.getOtherIcon(polygon.name)
+				val sanitizedOther = PolygonMapItem(polygon.placemark, icon, polygon.points)
+				sanitizedOtherBounds.add(sanitizedOther)
 			}
 
 			Locations.otherBounds = sanitizedOtherBounds

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -37,9 +37,10 @@ import xyz.thespud.skimap.mapItem.PolygonMapItem
 import xyz.thespud.skimap.mapItem.PolylineMapItem
 import xyz.thespud.skimap.mapItem.SkiRuns
 
-abstract class MapHandler(private val activity: FragmentActivity, private val cameraPosition: CameraPosition,
-                          private val cameraBounds: LatLngBounds?, private val skiRuns: SkiRuns,
-                          private val otherIconCallback: CustomIcons, private val drawOpaqueRuns: Boolean, private val showDebug: Boolean): OnMapReadyCallback {
+abstract class MapHandler(private val activity: FragmentActivity, private val view: View,
+                          private val cameraPosition: CameraPosition, private val cameraBounds: LatLngBounds?,
+                          private val skiRuns: SkiRuns, private val otherIconCallback: CustomIcons,
+                          private val drawOpaqueRuns: Boolean, private val showDebug: Boolean): OnMapReadyCallback {
 
 	internal var googleMap: GoogleMap? = null
 
@@ -115,6 +116,8 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 		// Load the various polylines and polygons onto the map.
 		activity.lifecycleScope.launch(Dispatchers.Default) { loadSkiRuns() }
 
+		applyMapInsets(view, map)
+
 		googleMap = map
 
 		Log.d("onMapReady", "Running additional setup steps...")
@@ -123,19 +126,19 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 	}
 
 	// For fixing edge to edge behavior
-	fun applyMapInsets(view: View) {
-		ViewCompat.setOnApplyWindowInsetsListener(view) { view, insets ->
-			val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+	fun applyMapInsets(view: View, map: GoogleMap) {
+		ViewCompat.setOnApplyWindowInsetsListener(view) { _, insets ->
+			Log.v("applyMapInsets", "Applying map insets...")
 
-			val map = googleMap
-			if (map != null) {
-				map.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-			} else {
-				Log.w("applyMapInsets", "Map has not been set up")
-			}
+			val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+			map.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
 
 			insets
 		}
+
+		// Request the insets be applied again since they may have already been applied to the view,
+		// and we want our newly set listener to run
+		view.requestApplyInsets()
 	}
 
 	private suspend fun loadSkiRuns() = coroutineScope {

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -47,38 +47,6 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 
 	abstract val additionalCallback: OnMapReadyCallback
 
-	/*
-	var chairliftPolylines: List<PolylineMapItem> = emptyList()
-		private set
-	var greenRunPolylines: List<PolylineMapItem> = emptyList()
-		private set
-	var blueRunPolylines: List<PolylineMapItem> = emptyList()
-		private set
-	var blackRunPolylines: List<PolylineMapItem> = emptyList()
-		private set
-	var doubleBlackRunPolylines: List<PolylineMapItem> = emptyList()
-		private set
-
-	var skiAreaBounds: PolygonMapItem? = null
-		private set
-
-	var otherBounds: List<PolygonMapItem> = emptyList()
-		private set
-	var startingChairliftTerminals: List<PolygonMapItem> = emptyList()
-		private set
-	var endingChairliftTerminals: List<PolygonMapItem> = emptyList()
-		private set
-
-	var greenRunBounds: List<PolygonMapItem> = emptyList()
-		private set
-	var blueRunBounds: List<PolygonMapItem> = emptyList()
-		private set
-	var blackRunBounds: List<PolygonMapItem> = emptyList()
-		private set
-	var doubleBlackRunBounds: List<PolygonMapItem> = emptyList()
-		private set
-	 */
-
 	open fun destroy() {
 
 		for (chairliftPolyline in Locations.chairliftPolylines) {
@@ -158,8 +126,14 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 	fun applyMapInsets(view: View) {
 		ViewCompat.setOnApplyWindowInsetsListener(view) { view, insets ->
 			val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-			googleMap?.setPadding(systemBars.left, systemBars.top, systemBars.right,
-				systemBars.bottom)
+
+			val map = googleMap
+			if (map != null) {
+				map.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+			} else {
+				Log.w("applyMapInsets", "Map has not been set up")
+			}
+
 			insets
 		}
 	}
@@ -400,7 +374,7 @@ abstract class MapHandler(private val activity: FragmentActivity, private val ca
 				activity
 				val argb = activity.getColor(color)
 
-				/*val polygon = */withContext(Dispatchers.Main) {
+				withContext(Dispatchers.Main) {
 					googleMap?.addPolygon {
 						addAll(kmlPolygon.outerBoundaryCoordinates)
 						clickable(false)

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/mapItem/Locations.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/mapItem/Locations.kt
@@ -24,7 +24,8 @@ object Locations {
 	var blackRunPolylines: List<PolylineMapItem> = emptyList()
 	var doubleBlackRunPolylines: List<PolylineMapItem> = emptyList()
 
-	lateinit var skiAreaBounds: PolygonMapItem
+	// Cannot be lateinit var because of a race-condition with location updates occurring before this has been set
+	var skiAreaBounds: PolygonMapItem? = null
 
 	var otherBounds: List<PolygonMapItem> = emptyList()
 	var startingChairliftTerminals: List<PolygonMapItem> = emptyList()

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/mapItem/MapItem.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/mapItem/MapItem.kt
@@ -5,7 +5,7 @@ import androidx.annotation.DrawableRes
 import com.google.maps.android.data.kml.KmlPlacemark
 import java.util.Collections
 
-abstract class MapItem(placemark: KmlPlacemark, @DrawableRes val icon: Int) {
+abstract class MapItem(val placemark: KmlPlacemark, @DrawableRes val icon: Int) {
 
 	val name: String
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
@@ -100,9 +100,15 @@ class SkierLocationService : Service(), LocationListener {
 	override fun onLocationChanged(location: Location) {
 		Log.v(TAG, "Location updated")
 
+		val bounds = Locations.skiAreaBounds
+		if (bounds == null) {
+			Log.w(TAG, "Bounds not set before update")
+			return
+		}
+
 		// If we are not on the mountain stop the tracking.
 		if (!PolyUtil.containsLocation(location.latitude, location.longitude,
-				Locations.skiAreaBounds.points, true)) {
+				bounds.points, true)) {
 			Toast.makeText(this, R.string.out_of_bounds,
 				Toast.LENGTH_LONG).show()
 			SkiingNotification.cancelTrackingNotification(this)

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
@@ -123,6 +123,10 @@ class SkierLocationService : Service(), LocationListener {
 		}
 
 		Locations.updateLocations(location)
+
+		//callback?.onLocationUpdated(location)
+		sendBroadcast(Intent(UPDATE_TRACKING_BROADCAST))
+
 		val intent = Intent(this, LiveMapActivity::class.java)
 
 		var mapMarker = Locations.getOnLocation()
@@ -138,9 +142,6 @@ class SkierLocationService : Service(), LocationListener {
 				applicationInfo.icon, R.string.current_other, mapMarker)
 			return
 		}
-
-		//callback?.onLocationUpdated(location)
-		sendBroadcast(Intent(UPDATE_TRACKING_BROADCAST))
 
 		SkiingNotification.updateTrackingNotification(this, intent,
 			applicationInfo.icon, getString(R.string.tracking_notice), null)

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
@@ -9,7 +9,6 @@ import android.content.pm.ServiceInfo
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
-import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -22,15 +21,6 @@ import xyz.thespud.skimap.activities.LiveMapActivity
 import xyz.thespud.skimap.mapItem.Locations
 
 class SkierLocationService : Service(), LocationListener {
-
-	inner class LocalBinder: Binder() {
-		fun getService(): SkierLocationService = this@SkierLocationService
-	}
-
-	// FIXME Memory leak here
-	private var binder: IBinder = LocalBinder()
-
-	// private var callback: LocationCallbacks? = null
 
 	private lateinit var locationManager: LocationManager
 
@@ -64,7 +54,6 @@ class SkierLocationService : Service(), LocationListener {
 					startForeground(SkiingNotification.TRACKING_SERVICE_ID, notification)
 				}
 
-				//callback?.onTrackingStarted()
 				sendBroadcast(Intent(START_TRACKING_BROADCAST))
 			}
 			STOP_TRACKING_INTENT -> {
@@ -124,7 +113,6 @@ class SkierLocationService : Service(), LocationListener {
 
 		Locations.updateLocations(location)
 
-		//callback?.onLocationUpdated(location)
 		sendBroadcast(Intent(UPDATE_TRACKING_BROADCAST))
 
 		val intent = Intent(this, LiveMapActivity::class.java)
@@ -148,18 +136,12 @@ class SkierLocationService : Service(), LocationListener {
 	}
 
 	fun stopService() {
-		//callback?.onTrackingStopped()
 		sendBroadcast(Intent(STOP_TRACKING_BROADCAST))
 		stopForeground(STOP_FOREGROUND_REMOVE)
 		stopSelf()
 	}
 
-	/*
-	fun setCallback(callback: LocationCallbacks) {
-		this.callback = callback
-	}*/
-
-	override fun onBind(intent: Intent?): IBinder { return binder }
+	override fun onBind(intent: Intent?): IBinder? { return null }
 
 	override fun onProviderEnabled(provider: String) {}
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/services/SkierLocationService.kt
@@ -3,11 +3,9 @@ package xyz.thespud.skimap.services
 import android.Manifest
 import android.app.Notification
 import android.app.Service
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
-import android.graphics.Color
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
@@ -18,16 +16,10 @@ import android.os.IBinder
 import android.util.Log
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
-import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.maps.android.PolyUtil
 import xyz.thespud.skimap.R
 import xyz.thespud.skimap.activities.LiveMapActivity
-import xyz.thespud.skimap.activities.MapHandler
 import xyz.thespud.skimap.mapItem.Locations
-import xyz.thespud.skimap.mapItem.Locations.chairliftIcon
-import xyz.thespud.skimap.mapItem.MapMarker
-import xyz.thespud.skimap.mapItem.PolygonMapItem
-import java.lang.ref.WeakReference
 
 class SkierLocationService : Service(), LocationListener {
 
@@ -37,6 +29,8 @@ class SkierLocationService : Service(), LocationListener {
 
 	// FIXME Memory leak here
 	private var binder: IBinder = LocalBinder()
+
+	// private var callback: LocationCallbacks? = null
 
 	private lateinit var locationManager: LocationManager
 
@@ -69,6 +63,9 @@ class SkierLocationService : Service(), LocationListener {
 				} else {
 					startForeground(SkiingNotification.TRACKING_SERVICE_ID, notification)
 				}
+
+				//callback?.onTrackingStarted()
+				sendBroadcast(Intent(START_TRACKING_BROADCAST))
 			}
 			STOP_TRACKING_INTENT -> {
 				Log.d(TAG, "Stopping foreground service")
@@ -142,19 +139,26 @@ class SkierLocationService : Service(), LocationListener {
 			return
 		}
 
+		//callback?.onLocationUpdated(location)
+		sendBroadcast(Intent(UPDATE_TRACKING_BROADCAST))
+
 		SkiingNotification.updateTrackingNotification(this, intent,
 			applicationInfo.icon, getString(R.string.tracking_notice), null)
 	}
 
 	fun stopService() {
+		//callback?.onTrackingStopped()
+		sendBroadcast(Intent(STOP_TRACKING_BROADCAST))
 		stopForeground(STOP_FOREGROUND_REMOVE)
 		stopSelf()
 	}
 
+	/*
+	fun setCallback(callback: LocationCallbacks) {
+		this.callback = callback
+	}*/
 
-	override fun onBind(intent: Intent?): IBinder? {
-		return binder
-	}
+	override fun onBind(intent: Intent?): IBinder { return binder }
 
 	override fun onProviderEnabled(provider: String) {}
 
@@ -168,8 +172,10 @@ class SkierLocationService : Service(), LocationListener {
 		const val TAG = "SkierLocationService"
 
 		const val STOP_TRACKING_INTENT = "xyz.thespud.skimap.SkierLocationService.Stop"
-
 		const val START_TRACKING_INTENT = "xyz.thespud.skimap.SkierLocationService.Start"
 
+		const val START_TRACKING_BROADCAST = "xyz.thespud.skimap.SkierLocationService.Broadcast.Start"
+		const val UPDATE_TRACKING_BROADCAST = "xyz.thespud.skimap.SkierLocationService.Broadcast.Update"
+		const val STOP_TRACKING_BROADCAST = "xyz.thespud.skimap.SkierLocationService.Broadcast.Stop"
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.nonTransitiveRClass=true
 
 GROUP=xyz.thespud
 POM_ARTIFACT_ID=spuds-ski-map
-VERSION_NAME=2026.05.09
+VERSION_NAME=2026.05.10
 
 POM_NAME=Spud's Ski Map
 POM_DESCRIPTION=An android library for setting up ski maps with Google Maps


### PR DESCRIPTION
Changes:
* Created a mandatory callback implementation for setting custom icons
* Changed from binder communication to broadcast-receivers for when location tracking starts, updates, and stops

Example broadcast receivers are as follows:

```kotlin
private val startTrackingReceiver = object : BroadcastReceiver() {
	override fun onReceive(context: Context?, intent: Intent?) {
		Log.d("startTrackingReceiver", "Received broadcast to start tracking")
		
		// ...
		
	}
}

private val updateTrackingReceiver = object : BroadcastReceiver() {
	override fun onReceive(context: Context?, intent: Intent?) {
		Log.d("updateTrackingReceiver", "Received broadcast to update tracking")
		
		// ...
		
	}
}

private val stopTrackingReceiver = object : BroadcastReceiver() {
	override fun onReceive(context: Context?, intent: Intent?) {
		Log.d("stopTrackingReceiver", "Received broadcast to stop tracking")
		
		// ...
		
	}
}
```