### PR TITLE
Add broadcast for when map is ready

### DIFF
--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
@@ -39,8 +39,6 @@ class InfoMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 	private set
 
 	override fun onMapReady(map: GoogleMap) {
-		super.onMapReady(map)
-
 		map.setOnCircleClickListener {
 			Log.v("onCircleClicked", "Circle clicked!")
 			map.setInfoWindowAdapter(this)
@@ -83,9 +81,12 @@ class InfoMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 
 		activity.lifecycleScope.launch(Dispatchers.Main) {
 			locationManager = InfoLocationManager(skiAreaObjects, icons, map, activity)
+			setLocationManagerReady()
 		}
 
 		map.setOnInfoWindowCloseListener { it.isVisible = false }
+
+		super.onMapReady(map)
 	}
 
 	override fun destroy() {

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
@@ -26,8 +26,8 @@ import kotlin.math.roundToInt
 
 class InfoMapActivity(val activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
                       cameraBounds: LatLngBounds?, skiAreaObjects: SkiAreaObjects, icons: CustomIcons,
-                      showDebug: Boolean = false): MapHandler(view, cameraPosition, cameraBounds,
-	showDebug), GoogleMap.InfoWindowAdapter {
+                      showDebug: Boolean = false): MapHandler(view, cameraPosition, cameraBounds, skiAreaObjects,
+	icons, showDebug), GoogleMap.InfoWindowAdapter {
 
 	override var locationManager: InfoLocationManager? = null
 
@@ -38,9 +38,8 @@ class InfoMapActivity(val activity: ComponentActivity, view: View, cameraPositio
 	var loadedSkiRuns: List<SkiRun> = emptyList()
 	private set
 
-	@SuppressLint("PotentialBehaviorOverride")
-	override val additionalCallback: OnMapReadyCallback = OnMapReadyCallback { map ->
-		Log.v("additionalCallback", "additionalCallback called for InfoMapActivity")
+	override fun onMapReady(map: GoogleMap) {
+		super.onMapReady(map)
 
 		map.setOnCircleClickListener {
 			Log.v("onCircleClicked", "Circle clicked!")

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/InfoMapActivity.kt
@@ -1,6 +1,5 @@
 package xyz.thespud.skimap.activities
 
-import android.annotation.SuppressLint
 import android.location.Location
 import android.util.Log
 import android.view.View
@@ -8,7 +7,6 @@ import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.maps.GoogleMap
-import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
@@ -24,12 +22,14 @@ import xyz.thespud.skimap.mapItem.InfoMapMarker
 import xyz.thespud.skimap.mapItem.SkiRun
 import kotlin.math.roundToInt
 
-class InfoMapActivity(val activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
+class InfoMapActivity(activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
                       cameraBounds: LatLngBounds?, skiAreaObjects: SkiAreaObjects, icons: CustomIcons,
-                      showDebug: Boolean = false): MapHandler(view, cameraPosition, cameraBounds, skiAreaObjects,
-	icons, showDebug), GoogleMap.InfoWindowAdapter {
+                      showDebug: Boolean = false): MapHandler(activity, view, cameraPosition, cameraBounds,
+	skiAreaObjects, icons, showDebug), GoogleMap.InfoWindowAdapter {
 
 	override var locationManager: InfoLocationManager? = null
+
+	override val mapReadyBroadcastFilter: String = BROADCASTFILTER
 
 	private var runMarker: Marker? = null
 
@@ -194,5 +194,9 @@ class InfoMapActivity(val activity: ComponentActivity, view: View, cameraPositio
 	override fun getInfoWindow(marker: Marker): View? {
 		Log.v("InfoMapActivity", "getInfoWindow called")
 		return null
+	}
+
+	companion object {
+		const val BROADCASTFILTER = "xyz.thespud.skimap.InfoMapBroadcast"
 	}
 }

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -35,12 +35,10 @@ import xyz.thespud.skimap.services.SkiingNotification.NOTIFICATION_PERMISSION
 
 class LiveMapActivity(val activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
                       cameraBounds: LatLngBounds?, skiAreaObjects: SkiAreaObjects, icons: CustomIcons,
-                      showDebug: Boolean = false): MapHandler(view,
-	cameraPosition, cameraBounds, showDebug), GoogleMap.OnMyLocationClickListener {
+                      showDebug: Boolean = false): MapHandler(view, cameraPosition, cameraBounds, skiAreaObjects,
+	icons, showDebug), GoogleMap.OnMyLocationClickListener {
 
 	override lateinit var locationManager: LiveLocationManager
-
-	var isMapSetup = false
 
 	var manuallyDisabled = false
 	private set
@@ -54,8 +52,8 @@ class LiveMapActivity(val activity: ComponentActivity, view: View, cameraPositio
 		override fun onReceive(context: Context?, intent: Intent?) { setIsTracking(false) }
 	}
 
-	override val additionalCallback: OnMapReadyCallback = OnMapReadyCallback { map ->
-		Log.v("additionalCallback", "additionalCallback called for LiveMapActivity")
+	override fun onMapReady(map: GoogleMap) {
+		super.onMapReady(map)
 
 		activity.lifecycleScope.launch(Dispatchers.Main) {
 			locationManager = LiveLocationManager.getInstance(skiAreaObjects, icons, map,
@@ -87,8 +85,6 @@ class LiveMapActivity(val activity: ComponentActivity, view: View, cameraPositio
 			// Show the info popup about location.
 			alertDialogBuilder.create().show()
 		}
-
-		isMapSetup = true
 	}
 
 	// fixme callback not being called when location dot is clicked

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -118,6 +118,7 @@ class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 
 	fun launchLocationService() {
 
+		// Make sure we have the proper permissions to track the user's location
 		if (ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS)
 			== PackageManager.PERMISSION_DENIED) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -143,9 +144,7 @@ class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 			@Suppress("DEPRECATION")
 			for (runningServices in activityManager.getRunningServices(Int.MAX_VALUE)) {
 				if (SkierLocationService::class.java.name == runningServices.service.className) {
-					if (runningServices.foreground) {
-						return
-					}
+					if (runningServices.foreground) { return }
 				}
 			}
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -21,7 +21,6 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.maps.GoogleMap
-import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLngBounds
 import kotlinx.coroutines.Dispatchers
@@ -33,12 +32,14 @@ import xyz.thespud.skimap.locationmanager.SkiAreaObjects
 import xyz.thespud.skimap.services.SkierLocationService
 import xyz.thespud.skimap.services.SkiingNotification.NOTIFICATION_PERMISSION
 
-class LiveMapActivity(val activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
+class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: CameraPosition,
                       cameraBounds: LatLngBounds?, skiAreaObjects: SkiAreaObjects, icons: CustomIcons,
-                      showDebug: Boolean = false): MapHandler(view, cameraPosition, cameraBounds, skiAreaObjects,
-	icons, showDebug), GoogleMap.OnMyLocationClickListener {
+                      showDebug: Boolean = false): MapHandler(activity, view, cameraPosition, cameraBounds,
+	skiAreaObjects, icons, showDebug), GoogleMap.OnMyLocationClickListener {
 
 	override lateinit var locationManager: LiveLocationManager
+
+	override val mapReadyBroadcastFilter: String = BROADCASTFILTER
 
 	var manuallyDisabled = false
 	private set
@@ -170,5 +171,7 @@ class LiveMapActivity(val activity: ComponentActivity, view: View, cameraPositio
 
 	companion object {
 		const val permissionValue = 29500
+
+		const val BROADCASTFILTER = "xyz.thespud.skimap.LiveMapBroadcast"
 	}
 }

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -54,11 +54,11 @@ class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 	}
 
 	override fun onMapReady(map: GoogleMap) {
-		super.onMapReady(map)
 
 		activity.lifecycleScope.launch(Dispatchers.Main) {
 			locationManager = LiveLocationManager.getInstance(skiAreaObjects, icons, map,
 				activity, false)
+			setLocationManagerReady()
 		}
 
 		// Determine if the user has enabled location permissions.
@@ -86,6 +86,8 @@ class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 			// Show the info popup about location.
 			alertDialogBuilder.create().show()
 		}
+
+		super.onMapReady(map)
 	}
 
 	// fixme callback not being called when location dot is clicked

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/LiveMapActivity.kt
@@ -156,6 +156,7 @@ class LiveMapActivity(activity: ComponentActivity, view: View, cameraPosition: C
 
 	override fun destroy() {
 		super.destroy()
+		locationManager.destroy()
 		activity.unregisterReceiver(startTrackingReceiver)
 		activity.unregisterReceiver(stopTrackingReceiver)
 	}

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -16,12 +16,14 @@ import xyz.thespud.skimap.locationmanager.LocationManager
 import xyz.thespud.skimap.locationmanager.SkiAreaObjects
 
 abstract class MapHandler(val activity: ComponentActivity, private val view: View, private val cameraPosition: CameraPosition,
-                          private val cameraBounds: LatLngBounds?, internal val skiAreaObjects: SkiAreaObjects,
-                          internal val icons: CustomIcons, private val showDebug: Boolean): OnMapReadyCallback {
+                          private val cameraBounds: LatLngBounds?, protected val skiAreaObjects: SkiAreaObjects,
+                          protected val icons: CustomIcons, private val showDebug: Boolean): OnMapReadyCallback {
 
-	internal var googleMap: GoogleMap? = null
+	protected var googleMap: GoogleMap? = null
+	private var mapReady = false
 
 	abstract val locationManager: LocationManager<*>?
+	private var locationManagerReady = false
 
 	var isNightOnly = false
 
@@ -55,6 +57,7 @@ abstract class MapHandler(val activity: ComponentActivity, private val view: Vie
 
 		// Clear the map if it's not null.
 		Log.v("MapHandler", "Clearing map.")
+		mapReady = false
 		googleMap?.clear()
 
 		// Add broadcast for map event with am intent that has an extra boolean of MAPREADY = FALSE
@@ -101,17 +104,11 @@ abstract class MapHandler(val activity: ComponentActivity, private val view: Vie
 		map.isIndoorEnabled = false
 		map.mapType = GoogleMap.MAP_TYPE_SATELLITE
 
-		// Load the various polylines and polygons onto the map.
-		// activity.lifecycleScope.launch(Dispatchers.Default) { loadSkiRuns() }
-
 		applyMapInsets(view, map)
 
 		googleMap = map
 
-		// Add broadcast for map event with am intent that has an extra boolean of MAPREADY = TRUE
-		val broadcastIntent = Intent(mapReadyBroadcastFilter)
-		broadcastIntent.putExtra(MAPREADY, true)
-		activity.sendBroadcast(broadcastIntent)
+		setMapReady()
 	}
 
 	// For fixing edge to edge behavior
@@ -128,6 +125,35 @@ abstract class MapHandler(val activity: ComponentActivity, private val view: Vie
 		// Request the insets be applied again since they may have already been applied to the view,
 		// and we want our newly set listener to run
 		view.requestApplyInsets()
+	}
+
+	private fun checkBroadcast() {
+
+		if (mapReady && locationManagerReady) {
+
+			// Add broadcast for map event with am intent that has an extra boolean of MAPREADY = TRUE
+			val broadcastIntent = Intent(mapReadyBroadcastFilter)
+			broadcastIntent.putExtra(MAPREADY, true)
+			activity.sendBroadcast(broadcastIntent)
+
+		} else {
+
+			val TAG = "checkBroadcast"
+
+			if (!mapReady) { Log.i(TAG, "Map not ready") }
+
+			if (!locationManagerReady){ Log.i(TAG, "Location manager not ready") }
+		}
+	}
+
+	protected fun setMapReady() {
+		mapReady = true
+		checkBroadcast()
+	}
+
+	protected fun setLocationManagerReady() {
+		locationManagerReady = true
+		checkBroadcast()
 	}
 
 	companion object {

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -1,7 +1,9 @@
 package xyz.thespud.skimap.activities
 
+import android.content.Intent
 import android.util.Log
 import android.view.View
+import androidx.activity.ComponentActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -13,7 +15,7 @@ import xyz.thespud.skimap.locationmanager.CustomIcons
 import xyz.thespud.skimap.locationmanager.LocationManager
 import xyz.thespud.skimap.locationmanager.SkiAreaObjects
 
-abstract class MapHandler(private val view: View, private val cameraPosition: CameraPosition,
+abstract class MapHandler(val activity: ComponentActivity, private val view: View, private val cameraPosition: CameraPosition,
                           private val cameraBounds: LatLngBounds?, internal val skiAreaObjects: SkiAreaObjects,
                           internal val icons: CustomIcons, private val showDebug: Boolean): OnMapReadyCallback {
 
@@ -22,6 +24,8 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 	abstract val locationManager: LocationManager<*>?
 
 	var isNightOnly = false
+
+	abstract val mapReadyBroadcastFilter: String
 
 	open fun destroy() {
 
@@ -49,12 +53,14 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 			}
 		}
 
-		// Clear the map if its not null.
+		// Clear the map if it's not null.
 		Log.v("MapHandler", "Clearing map.")
 		googleMap?.clear()
 
-		// todo Add broadcast for map event with am intent that has an extra boolean of MAPREADY = FALSE
-
+		// Add broadcast for map event with am intent that has an extra boolean of MAPREADY = FALSE
+		val broadcastIntent = Intent(mapReadyBroadcastFilter)
+		broadcastIntent.putExtra(MAPREADY, false)
+		activity.sendBroadcast(broadcastIntent)
 
 		// This frees up a bunch of ram, so call the garbage collection to collect the free ram
 		System.gc()
@@ -102,7 +108,10 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 
 		googleMap = map
 
-		// FIXME Add broadcast for map event with am intent that has an extra boolean of MAPREADY = TRUE
+		// Add broadcast for map event with am intent that has an extra boolean of MAPREADY = TRUE
+		val broadcastIntent = Intent(mapReadyBroadcastFilter)
+		broadcastIntent.putExtra(MAPREADY, true)
+		activity.sendBroadcast(broadcastIntent)
 	}
 
 	// For fixing edge to edge behavior
@@ -122,6 +131,9 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 	}
 
 	companion object {
+
+		const val MAPREADY = "MapReady"
+
 		private const val MINIMUM_ZOOM = 13.0F
 		private const val MAXIMUM_ZOOM = 20.0F
 	}

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -9,18 +9,19 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLngBounds
+import xyz.thespud.skimap.locationmanager.CustomIcons
 import xyz.thespud.skimap.locationmanager.LocationManager
+import xyz.thespud.skimap.locationmanager.SkiAreaObjects
 
 abstract class MapHandler(private val view: View, private val cameraPosition: CameraPosition,
-                          private val cameraBounds: LatLngBounds?, private val showDebug: Boolean): OnMapReadyCallback {
+                          private val cameraBounds: LatLngBounds?, internal val skiAreaObjects: SkiAreaObjects,
+                          internal val icons: CustomIcons, private val showDebug: Boolean): OnMapReadyCallback {
 
 	internal var googleMap: GoogleMap? = null
 
 	abstract val locationManager: LocationManager<*>?
 
 	var isNightOnly = false
-
-	abstract val additionalCallback: OnMapReadyCallback
 
 	open fun destroy() {
 
@@ -51,6 +52,9 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 		// Clear the map if its not null.
 		Log.v("MapHandler", "Clearing map.")
 		googleMap?.clear()
+
+		// todo Add broadcast for map event with am intent that has an extra boolean of MAPREADY = FALSE
+
 
 		// This frees up a bunch of ram, so call the garbage collection to collect the free ram
 		System.gc()
@@ -98,9 +102,7 @@ abstract class MapHandler(private val view: View, private val cameraPosition: Ca
 
 		googleMap = map
 
-		Log.d("onMapReady", "Running additional setup steps...")
-		additionalCallback.onMapReady(googleMap!!)
-		Log.d("onMapReady", "Finished setting up map.")
+		// FIXME Add broadcast for map event with am intent that has an extra boolean of MAPREADY = TRUE
 	}
 
 	// For fixing edge to edge behavior

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/activities/MapHandler.kt
@@ -66,6 +66,7 @@ abstract class MapHandler(val activity: ComponentActivity, private val view: Vie
 		activity.sendBroadcast(broadcastIntent)
 
 		// This frees up a bunch of ram, so call the garbage collection to collect the free ram
+		locationManagerReady = false
 		System.gc()
 	}
 

--- a/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/locationmanager/LiveLocationManager.kt
+++ b/Spuds-Ski-Map/src/main/java/xyz/thespud/skimap/locationmanager/LiveLocationManager.kt
@@ -105,6 +105,11 @@ class LiveLocationManager private constructor(skiAreaObjects: SkiAreaObjects, ic
 		return null
 	}
 
+	fun destroy() {
+		Log.d("LiveLocationManager", "Destroying singleton instance")
+		instance = null
+	}
+
 	companion object {
 
 		@Volatile

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.nonTransitiveRClass=true
 
 GROUP=xyz.thespud
 POM_ARTIFACT_ID=spuds-ski-map
-VERSION_NAME=2026.06.28
+VERSION_NAME=2026.06.29
 
 POM_NAME=Spud's Ski Map
 POM_DESCRIPTION=An android library for setting up ski maps with Google Maps


### PR DESCRIPTION
+ Added a broadcast event for when the map is ready. This includes the google map being ready, and the location manager being ready
    - This new broadcast can be utilizing by registering a broadcast receiver 
    ```kotlin
    private val mapReadyReceiver = object : BroadcastReceiver() {
		override fun onReceive(context: Context?, intent: Intent?) {
			if (intent == null) { return }

			val isMapReady = intent.getBooleanExtra(MapHandler.MAPREADY, false)
			if (isMapReady) { ... }
		}
	}
    ```
    - To register this receiver add this to your `onCreate()`:
    ```kotlin
    ContextCompat.registerReceiver(this, mapReadyReceiver,
			IntentFilter((Either LiveMapActivity or InfoMapActivity).BROADCASTFILTER),
			ContextCompat.RECEIVER_EXPORTED)
    ```
    - Dont forget to unregister the receiver in `onDestroy()` with `unregisterReceiver(mapReadyReceiver)`


* Fixed a bug where the live map would not repopulate upon reopening